### PR TITLE
Add GoldenDict lookup in macOS

### DIFF
--- a/helpers/goldendict_lookups.py
+++ b/helpers/goldendict_lookups.py
@@ -5,7 +5,7 @@ import subprocess
 from distutils.spawn import find_executable
 
 GD_PROGRAM_NAME = "GoldenDict-NG"
-GD_EXE = find_executable("goldendict")
+GD_EXE = find_executable("goldendict") or "/Applications/GoldenDict.app/Contents/MacOS/GoldenDict"
 
 
 def lookup_goldendict(gd_word: str) -> subprocess.Popen:

--- a/helpers/goldendict_lookups.py
+++ b/helpers/goldendict_lookups.py
@@ -1,18 +1,31 @@
 # Copyright: Ren Tatsumoto <tatsu at autistici.org> and contributors
 # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
 
+import functools
+import os
 import subprocess
 from distutils.spawn import find_executable
+from typing import Optional
+
+from anki.utils import is_mac
 
 GD_PROGRAM_NAME = "GoldenDict-NG"
-GD_EXE = find_executable("goldendict") or "/Applications/GoldenDict.app/Contents/MacOS/GoldenDict"
+
+
+@functools.cache
+def find_goldendict() -> Optional[str]:
+    gd_exe = find_executable("goldendict")
+    gd_macos_location = "/Applications/GoldenDict.app/Contents/MacOS/GoldenDict"
+    if gd_exe is None and is_mac and os.path.isfile(gd_macos_location):
+        gd_exe = gd_macos_location
+    return gd_exe
 
 
 def lookup_goldendict(gd_word: str) -> subprocess.Popen:
-    if GD_EXE is None:
+    if find_goldendict() is None:
         raise RuntimeError(f"{GD_PROGRAM_NAME} is not installed. Doing nothing.")
     return subprocess.Popen(
-        (GD_EXE, gd_word),
+        (find_goldendict(), gd_word),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         stdin=subprocess.DEVNULL,


### PR DESCRIPTION
In macOS, GoldenDict is supposed to be installed to the (always) same path `/Applications/GoldenDict.app/` without binary linking, so there is no need look up. 

Short-circuiting will ensure that in case of symlinked binary (or *nix) the lookup will stop after the binary is found.