### PR TITLE
handle the GoldenDict-ng name change in the latest version

### DIFF
--- a/helpers/goldendict_lookups.py
+++ b/helpers/goldendict_lookups.py
@@ -14,11 +14,19 @@ except ImportError:
     from ajt_common.utils import find_executable
 
 GD_PROGRAM_NAME = "GoldenDict-NG"
+GDNG_MACOS_PATH = "/Applications/GoldenDict-ng.app/Contents/MacOS/GoldenDict-ng"
 GD_MACOS_PATH = "/Applications/GoldenDict.app/Contents/MacOS/GoldenDict"
 
 
 def find_goldendict_fallback() -> Optional[str]:
-    return GD_MACOS_PATH if (is_mac and os.path.isfile(GD_MACOS_PATH)) else None
+    if not is_mac:
+        return None
+    elif os.path.isfile(GDNG_MACOS_PATH):
+        return GDNG_MACOS_PATH
+    elif os.path.isfile(GD_MACOS_PATH):
+        return GD_MACOS_PATH
+    else:
+        return None
 
 
 @functools.cache


### PR DESCRIPTION
Hi, Goldendict-ng has changed its name from "GoldenDict" to "GoldenDict-ng" on macOS in its latest version, see [this commit](https://github.com/xiaoyifang/goldendict-ng/commit/9006c50b5ee8ac8364ae257b4237f9dd9d10a7c4). This PR reflects that change. The old name is still kept to be backward-compatible.