### PR TITLE
Updated gitsubmodules to https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "addon/ajt_common"]
 	path = japanese/ajt_common
-	url = git@github.com:Ajatt-Tools/ajt_common.git
+	url = https://github.com/Ajatt-Tools/ajt_common.git
 [submodule "addon/mecab_controller"]
 	path = japanese/mecab_controller
 	url = git@github.com:Ajatt-Tools/mecab_controller.git
+	url = https://github.com/Ajatt-Tools/mecab_controller.git


### PR DESCRIPTION
Currently your gitsubmodules are set up for a development environment that requires ssh access to github to pull the sources.  
This breaks in something like NixOS(my env) where the build process is sandboxed and doesn't have access to the user environment/ssh-keys  

If you pull directly from the https sources, this isn't a problem as they are public.